### PR TITLE
modify simple_uart_list to accept filter for UART port listing

### DIFF
--- a/simple_uart.h
+++ b/simple_uart.h
@@ -26,7 +26,7 @@ enum {
 // ie: /dev/ttyS0 etc... (or COM1: on Win32)
 // Returns the number of items in the list.
 // Caller is responsible for free'ing each name/description and the overall list
-int simple_uart_list(char ***namesp, char ***descriptionp);
+int simple_uart_list(char ***namesp, char ***descriptionp, int num, char **filtp);
 
 /**
  * Opens a uart, either by device name, or if that fails it will search


### PR DESCRIPTION
This PR enables the _simple_uart_ to accept user defined filters for UART port naming in linux/apple.

Modify ```simple_uart_list``` to accept UART device templates from user. Therefore are two new arguments introduced ```num``` number of entries in filter table ```**filtp``` as array of pointers.

Custom Filters can used with following example:
```c
char        **names;
char        **descriptions;
int         numUarts;
const char* myTTY[] = {
    "ttyACM[0-9]*"
};
const int   numMyTTY = 1;


numUarts = simple_uart_list(&names, &descriptions, numMyTTY, (char**) &myTTY);
for (int i = 0; i < numUarts; i++) {
    printf("Port %d: %s: %s\n", i, names[i], (descriptions && descriptions[i]) ? descriptions[i] : "unknown");
}
```

In case of the standard ports can the function called with:
```c
numUarts = simple_uart_list(&names, &descriptions, 0, NULL);
```
