### PR TITLE
Fix gcc compile warning in Linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,8 +15,5 @@ simple_uart_test: simple_uart_test.o simple_uart.o
 simple_uart_term: simple_uart_term.o simple_uart.o
 	$(CC) -o simple_uart_term simple_uart_term.o simple_uart.o
 
-ci: ./simple_uart.c
-	$(CC) -c -O -Werror -Wextra -Wimplicit -Wconversion -I . ./simple_uart.c -o ./simple_uart.o
-
 clean:
 	rm -f simple_uart_test *.o

--- a/Makefile
+++ b/Makefile
@@ -15,5 +15,8 @@ simple_uart_test: simple_uart_test.o simple_uart.o
 simple_uart_term: simple_uart_term.o simple_uart.o
 	$(CC) -o simple_uart_term simple_uart_term.o simple_uart.o
 
+ci: ./simple_uart.c
+	$(CC) -c -O -Werror -Wextra -Wimplicit -Wconversion -I . ./simple_uart.c -o ./simple_uart.o
+
 clean:
 	rm -f simple_uart_test *.o

--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ The library consists of a single .c and .h pair. To add it to a project, simply 
 
 Please submit a bug report if this does not work.
 
-## API
+## [API](./simple_uart.h)
 ```c
-int simple_uart_list(char ***namesp, char ***descriptionp);
+ssize_t simple_uart_list(char ***namesp, char ***descriptionp);
 ```
 
 List available UART ports and descriptions.
@@ -38,7 +38,7 @@ On success the number of elements in the *namesp* and *descriptionsp* lists will
 ```c
 char **names;
 char **descriptions;
-int nuarts = simple_uart_list(&names, &descriptions);
+int nuarts = (int) simple_uart_list(&names, &descriptions);
 for (int i = 0; i < nuarts; i++) {
 	printf("Port %d: %s: %s\n", i, names[i], (descriptions && descriptions[i]) ? descriptions[i] : "unknown");
 }
@@ -72,7 +72,7 @@ int simple_uart_close(struct simple_uart *uart);
 Close a previously opened UART.
 
 ```c
-int simple_uart_read(struct simple_uart *uart, void *buffer, int max_len);
+ssize_t simple_uart_read(struct simple_uart *uart, void *buffer, size_t max_len);
 ```
 Read bytes from the given UART.
 
@@ -87,7 +87,7 @@ Argument | Details
 Returns the number of bytes written to *buffer* (up to *max_len*). < 0 on failure.
 
 ```c
-int simple_uart_write(struct simple_uart *uart, const void *buffer, int len);
+ssize_t simple_uart_write(struct simple_uart *uart, const void *buffer, size_t len);
 ```
 Write bytes to the given UART.
 
@@ -102,7 +102,7 @@ Argument | Details
 Returns the number of bytes written from *buffer* to the UART. < 0 on failure.
 
 ```c
-int simple_uart_set_character_delay(struct simple_uart *uart, int delay_us);
+unsigned int simple_uart_set_character_delay(struct simple_uart *uart, unsigned int delay_us);
 ```
 Sets a delay to be specified between each character written when using *simple_uart_write*.
 This is useful when communicating with devices that do not support flow control, and are not able to process data at full baudrate
@@ -154,6 +154,6 @@ int simple_uart_send_break(struct simple_uart *uart);
 Send a serial break on the UART
 
 ```c
-int simple_uart_read_line(struct simple_uart *uart, char *result, int max_len, int ms_timeout);
+ssize_t simple_uart_read_line(struct simple_uart *uart, char *result, int max_len, int ms_timeout);
 ```
 Read bytes of data up to a carriage return/line feed.

--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ On success the number of elements in the *namesp* and *descriptionsp* lists will
 ```c
 char **names;
 char **descriptions;
-int nuarts = (int) simple_uart_list(&names, &descriptions);
-for (int i = 0; i < nuarts; i++) {
+ssize_t nuarts = simple_uart_list(&names, &descriptions);
+for (ssize_t i = 0; i < nuarts; i++) {
 	printf("Port %d: %s: %s\n", i, names[i], (descriptions && descriptions[i]) ? descriptions[i] : "unknown");
 }
 

--- a/simple_uart.c
+++ b/simple_uart.c
@@ -131,7 +131,7 @@ ssize_t simple_uart_write(struct simple_uart *sc, const void *buffer, size_t len
                 return (ssize_t) i;
             usleep(sc->char_delay_us);
         }
-        r = len
+        r = len;
     } else {
         r = write (sc->fd, buffer, len);
         if (r < 0)

--- a/simple_uart.c
+++ b/simple_uart.c
@@ -453,11 +453,10 @@ ssize_t simple_uart_list(char ***namesp, char ***descriptionp)
 #endif
 
     for (size_t path = 0; path < sizeof(path_globs) / sizeof(path_globs[0]); path++) {
-        if (path >= _SC_SSIZE_MAX)  // abort to avoid memory leakage
-            break;
         if (glob(path_globs[path], 0, NULL, &g) >= 0) {
             char buffer[100];
             char **new_names;
+            if ((count + g.gl_pathc) > _SC_SSIZE_MAX) break;    // abort to avoid memory leakage
             new_names = realloc(names, (count + g.gl_pathc) * sizeof(char *));
             if (!new_names)
             {

--- a/simple_uart.c
+++ b/simple_uart.c
@@ -127,7 +127,7 @@ ssize_t simple_uart_write(struct simple_uart *sc, const void *buffer, size_t len
             ssize_t e = write(sc->fd, &buf8[i], 1);
             if (e < 0)
                 return e;
-            if (e == 0) {
+            if (e == 0)
                 return (ssize_t) i;
             usleep(sc->char_delay_us);
         }

--- a/simple_uart.c
+++ b/simple_uart.c
@@ -122,12 +122,17 @@ ssize_t simple_uart_write(struct simple_uart *sc, const void *buffer, size_t len
     ssize_t r;
     if (sc->char_delay_us > 0) {
         const uint8_t *buf8 = buffer;
-        for (int i = 0; i < len; i++) {
+        for (size_t i = 0; i < len; i++) {
             ssize_t e = write(sc->fd, &buf8[i], 1);
             if (e < 0)
                 return e;
-            if (e == 0)
-                return i;
+            if (e == 0) {
+                if (!(((ssize_t) i) < 0 )) {
+                    return (ssize_t) i;
+                } else {
+                    return _SC_SSIZE_MAX;
+                }
+            }
             usleep(sc->char_delay_us);
         }
         if (!(((ssize_t) len) < 0 )) {
@@ -455,7 +460,7 @@ ssize_t simple_uart_list(char ***namesp, char ***descriptionp)
     char *path_globs[] = {"/dev/tty.*"};
 #endif
 
-    for (int path = 0; path < sizeof(path_globs) / sizeof(path_globs[0]); path++) {
+    for (size_t path = 0; path < sizeof(path_globs) / sizeof(path_globs[0]); path++) {
         if (glob(path_globs[path], 0, NULL, &g) >= 0) {
             char buffer[100];
             char **new_names;
@@ -538,7 +543,7 @@ ssize_t simple_uart_read_line(struct simple_uart *uart, char *buffer, int max_le
 {
     int pos = 0;
     int last = mseconds();
-    int now;
+    int now = mseconds();
 
     if (!buffer || max_len == 0)
         return -EINVAL;

--- a/simple_uart.c
+++ b/simple_uart.c
@@ -63,13 +63,13 @@ struct simple_uart
 #else
     int fd;
 #endif
-    int char_delay_us;
+    unsigned int char_delay_us;
     FILE *logfile;
 };
 
-int simple_uart_read(struct simple_uart *sc, void *buffer, int max_len)
+ssize_t simple_uart_read(struct simple_uart *sc, void *buffer, size_t max_len)
 {
-    int r = 0;
+    ssize_t r = 0;
 #ifdef WIN32
     COMMTIMEOUTS commTimeout;
 
@@ -106,31 +106,35 @@ int simple_uart_read(struct simple_uart *sc, void *buffer, int max_len)
         r = -errno;
 #endif
     if (r > 0 && sc->logfile) {
-        fwrite(buffer, r, 1, sc->logfile);
+        fwrite(buffer, (size_t) r, 1, sc->logfile);
         fflush(sc->logfile);
     }
     return r;
 }
 
-int simple_uart_write(struct simple_uart *sc, const void *buffer, int len)
+ssize_t simple_uart_write(struct simple_uart *sc, const void *buffer, size_t len)
 {
 #ifdef WIN32
-    int r = 0;
+    ssize_t r = 0;
     /* TODO: Support char_delay_us */
     WriteFile (sc->port, buffer, len, (LPDWORD)&r, NULL);
 #else
-    int r;
+    ssize_t r;
     if (sc->char_delay_us > 0) {
         const uint8_t *buf8 = buffer;
         for (int i = 0; i < len; i++) {
-            int e = write(sc->fd, &buf8[i], 1);
+            ssize_t e = write(sc->fd, &buf8[i], 1);
             if (e < 0)
                 return e;
             if (e == 0)
                 return i;
             usleep(sc->char_delay_us);
         }
-        r = len;
+        if (!(((ssize_t) len) < 0 )) {
+            r = (ssize_t) len;
+        } else {
+            r = _SC_SSIZE_MAX;
+        }
     } else {
         r = write (sc->fd, buffer, len);
         if (r < 0)
@@ -139,7 +143,7 @@ int simple_uart_write(struct simple_uart *sc, const void *buffer, int len)
 #endif
 
     if (r > 0 && sc->logfile) {
-        fwrite(buffer, r, 1, sc->logfile);
+        fwrite(buffer, (size_t) r, 1, sc->logfile);
         fflush(sc->logfile);
     }
 
@@ -163,7 +167,7 @@ static int simple_uart_set_config(struct simple_uart *sc, int speed, const char 
     return 0;
 #else
     struct termios options;
-    int sp = 0;
+    speed_t sp = B0;
 #ifdef __linux__
     int non_standard = 0;
 #else // __APPLE__ type casting
@@ -261,7 +265,7 @@ static int simple_uart_set_config(struct simple_uart *sc, int speed, const char 
         cfsetispeed(&options, sp);
     }
 
-    options.c_cflag &= ~(HUPCL);
+    options.c_cflag &= (tcflag_t) ~(HUPCL);
 
     options.c_cflag |= CREAD | CLOCAL;
 
@@ -269,10 +273,10 @@ static int simple_uart_set_config(struct simple_uart *sc, int speed, const char 
 
     // parity
     if (HAS_OPTION ('N'))
-        options.c_cflag &= ~PARENB;
+        options.c_cflag &= (tcflag_t) ~PARENB;
     else if (HAS_OPTION ('E')) {
         options.c_cflag |= PARENB;
-        options.c_cflag &= ~PARODD;
+        options.c_cflag &= (tcflag_t) ~PARODD;
     } else if (HAS_OPTION ('O')) {
         options.c_cflag |= PARENB;
         options.c_cflag |= PARODD;
@@ -281,13 +285,13 @@ static int simple_uart_set_config(struct simple_uart *sc, int speed, const char 
     if (HAS_OPTION ('2'))
         options.c_cflag |= CSTOPB;
     else
-        options.c_cflag &= ~CSTOPB;
+        options.c_cflag &= (tcflag_t) ~CSTOPB;
     /* Flush data on each write */
     if (HAS_OPTION('W'))
         options.c_lflag |= NOFLSH;
 
     // Character size
-    options.c_cflag &= ~CSIZE;
+    options.c_cflag &= (tcflag_t) ~CSIZE;
     if (HAS_OPTION ('8'))
         options.c_cflag |= CS8;
     else if (HAS_OPTION ('7'))
@@ -304,16 +308,16 @@ static int simple_uart_set_config(struct simple_uart *sc, int speed, const char 
         options.c_cflag &= ~CRTSCTS;
 
     // raw input mode
-    options.c_lflag &= ~(ICANON | ECHO | ECHOE | ISIG);
+    options.c_lflag &= (tcflag_t) ~(ICANON | ECHO | ECHOE | ISIG);
 
     // disable software flow control
-    options.c_iflag &= ~(IXON | IXOFF | IXANY);
+    options.c_iflag &= (tcflag_t) ~(IXON | IXOFF | IXANY);
 
     // maintain carriage return on input, and don't translate it
-    options.c_iflag &= ~(IGNCR | ICRNL | INLCR);
+    options.c_iflag &= (tcflag_t) ~(IGNCR | ICRNL | INLCR);
 
     // raw output mode
-    options.c_oflag &= ~OPOST;
+    options.c_oflag &= (tcflag_t) ~OPOST;
 
     options.c_cc[VTIME] = 0;
     options.c_cc[VMIN] = 0;
@@ -338,8 +342,8 @@ static int simple_uart_set_config(struct simple_uart *sc, int speed, const char 
         /* Check we can divide down */
         if ((ss.baud_base / speed) == 0)
             return -EINVAL;
-        ss.flags &= ~(ASYNC_SPD_MASK);
-        ss.flags |= ASYNC_SPD_CUST;
+        ss.flags &= (int) ~(ASYNC_SPD_MASK);
+        ss.flags |= (int) ASYNC_SPD_CUST;
         ss.custom_divisor = ss.baud_base / speed;
         if (ioctl(sc->fd, TIOCSSERIAL, &ss) < 0)
             return -errno;
@@ -428,20 +432,20 @@ int simple_uart_has_data(struct simple_uart *sc)
 #endif
 }
 
-int simple_uart_set_character_delay(struct simple_uart *sc, int delay_us)
+unsigned int simple_uart_set_character_delay(struct simple_uart *sc, unsigned int delay_us)
 {
-    int old_delay = sc->char_delay_us;
+    unsigned int old_delay = sc->char_delay_us;
     sc->char_delay_us = delay_us;
     return old_delay;
 }
 
-int simple_uart_list(char ***namesp, char ***descriptionp)
+ssize_t simple_uart_list(char ***namesp, char ***descriptionp)
 {
 #if defined(__linux__) || defined(__APPLE__)
     glob_t g;
     char **names = NULL;
     char **description = NULL;
-    int count = 0;
+    size_t count = 0;
 
 #ifdef __linux__
     char *path_globs[] = {"/sys/class/tty/ttyS[0-9]*", "/sys/class/tty/ttyUSB[0-9]*", "/sys/class/tty/ttyACM[0-9]*"};
@@ -463,7 +467,7 @@ int simple_uart_list(char ***namesp, char ***descriptionp)
                 return -ENOMEM;
             }
             names = new_names;
-            for (int i = count; i < count + g.gl_pathc; i++)
+            for (size_t i = count; i < count + g.gl_pathc; i++)
             {
                 sprintf(buffer, "/dev/%s", basename(g.gl_pathv[i - count]));
                 names[i] = strdup(buffer);
@@ -475,7 +479,13 @@ int simple_uart_list(char ***namesp, char ***descriptionp)
 
     *namesp = names;
     *descriptionp = description;
-    return count;
+    
+    if (!(((ssize_t) count) < 0)) {
+        return (ssize_t) count;
+    } else {
+        return _SC_SSIZE_MAX;
+    }
+    
 #else
     int pos = 0;
     char **names = NULL;
@@ -524,7 +534,7 @@ int simple_uart_set_logfile(struct simple_uart *uart, const char *logfile, ...)
     return 0;
 }
 
-int simple_uart_read_line(struct simple_uart *uart, char *buffer, int max_len, int timeout)
+ssize_t simple_uart_read_line(struct simple_uart *uart, char *buffer, int max_len, int timeout)
 {
     int pos = 0;
     int last = mseconds();
@@ -537,7 +547,7 @@ int simple_uart_read_line(struct simple_uart *uart, char *buffer, int max_len, i
 
     do {
         char ch;
-        int ret = simple_uart_read(uart, &ch, 1);
+        ssize_t ret = simple_uart_read(uart, &ch, 1);
         if (ret < 0)
             return ret;
         if (ret > 0) {

--- a/simple_uart.c
+++ b/simple_uart.c
@@ -131,11 +131,7 @@ ssize_t simple_uart_write(struct simple_uart *sc, const void *buffer, size_t len
                 return (ssize_t) i;
             usleep(sc->char_delay_us);
         }
-        if (!(((ssize_t) len) < 0 )) {
-            r = (ssize_t) len;
-        } else {
-            r = _SC_SSIZE_MAX;
-        }
+        r = len
     } else {
         r = write (sc->fd, buffer, len);
         if (r < 0)

--- a/simple_uart.h
+++ b/simple_uart.h
@@ -26,7 +26,7 @@ enum {
 // ie: /dev/ttyS0 etc... (or COM1: on Win32)
 // Returns the number of items in the list.
 // Caller is responsible for free'ing each name/description and the overall list
-int simple_uart_list(char ***namesp, char ***descriptionp);
+ssize_t simple_uart_list(char ***namesp, char ***descriptionp);
 
 /**
  * Opens a uart, either by device name, or if that fails it will search
@@ -36,11 +36,11 @@ struct simple_uart *simple_uart_open(const char *name, int speed, const char *mo
 int simple_uart_close(struct simple_uart *uart);
 
 /* Raw read/write */
-int simple_uart_read(struct simple_uart *uart, void *buffer, int max_len);
-int simple_uart_write(struct simple_uart *uart, const void *buffer, int len);
+ssize_t simple_uart_read(struct simple_uart *uart, void *buffer, size_t max_len);
+ssize_t simple_uart_write(struct simple_uart *uart, const void *buffer, size_t len);
 
 /* Sets the delay between sending each character when using uart_write */
-int simple_uart_set_character_delay(struct simple_uart *uart, int delay_us);
+unsigned int simple_uart_set_character_delay(struct simple_uart *uart, unsigned int delay_us);
 
 /**
  * Returns how many data bytes available on the uart
@@ -78,7 +78,7 @@ int simple_uart_send_break(struct simple_uart *uart);
  * Read data until either a line ending (carriage return/line feed) is seen,
  * or a timeout occurs
  */
-int simple_uart_read_line(struct simple_uart *uart, char *result, int max_len, int ms_timeout);
+ssize_t simple_uart_read_line(struct simple_uart *uart, char *result, int max_len, int ms_timeout);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Hi Andre,

this PR implements the following:
* Remove compile warnings from GCC in Linux
* Introduce Make CI target to compile only the API, all warnings are casted to error
* Update the Readme.md to the interface changes

I've tested in my environment.

BR,
Andreas
