### PR TITLE
Fix Windows Compile Warnings

### DIFF
--- a/simple_uart.c
+++ b/simple_uart.c
@@ -444,12 +444,11 @@ unsigned int simple_uart_set_character_delay(struct simple_uart *sc, unsigned in
     return old_delay;
 }
 
-ssize_t simple_uart_list(char ***namesp, char ***descriptionp)
+ssize_t simple_uart_list(char ***namesp)
 {
 #if defined(__linux__) || defined(__APPLE__)
     glob_t g;
     char **names = NULL;
-    char **description = NULL;
     size_t count = 0;
 
 #ifdef __linux__
@@ -482,10 +481,7 @@ ssize_t simple_uart_list(char ***namesp, char ***descriptionp)
             globfree(&g);
         }
     }
-
     *namesp = names;
-    *descriptionp = description;
-
     return (ssize_t) count;
 
 #else

--- a/simple_uart.c
+++ b/simple_uart.c
@@ -167,7 +167,7 @@ static int simple_uart_set_config(struct simple_uart *sc, int speed, const char 
     if (!GetCommState (sc->port, &options)) {
         ero = -GetLastError();
         if (ero > INT_MAX)
-            ero = INT_MAX;
+            return -1;
         return (int) ero;
     }
     /* parse mode string */
@@ -188,7 +188,7 @@ static int simple_uart_set_config(struct simple_uart *sc, int speed, const char 
     } else {
         options.StopBits = ONESTOPBIT;
     }
-        // Disable flushing the input and output queues when generating signals for the INT, QUIT, and SUSP characters.
+        // TODO: Disable flushing the input and output queues when generating signals for the INT, QUIT, and SUSP characters.
 //    if (HAS_OPTION('W')) {
 //        options.c_lflag |= NOFLSH;
 //  }
@@ -214,7 +214,7 @@ static int simple_uart_set_config(struct simple_uart *sc, int speed, const char 
     if (!SetCommState (sc->port, &options)) {
         ero = -GetLastError();
         if (ero > INT_MAX)
-            ero = INT_MAX;
+            return -1;
         return (int) ero;
     }
     /* graceful end */

--- a/simple_uart.h
+++ b/simple_uart.h
@@ -78,7 +78,7 @@ int simple_uart_send_break(struct simple_uart *uart);
  * Read data until either a line ending (carriage return/line feed) is seen,
  * or a timeout occurs
  */
-ssize_t simple_uart_read_line(struct simple_uart *uart, char *result, int max_len, int ms_timeout);
+ssize_t simple_uart_read_line(struct simple_uart *uart, char *result, int max_len, uint64_t ms_timeout);
 
 #ifdef __cplusplus
 }

--- a/simple_uart.h
+++ b/simple_uart.h
@@ -27,7 +27,7 @@ enum {
 // ie: /dev/ttyS0 etc... (or COM1: on Win32)
 // Returns the number of items in the list.
 // Caller is responsible for free'ing each name/description and the overall list
-ssize_t simple_uart_list(char ***namesp, char ***descriptionp);
+ssize_t simple_uart_list(char ***namesp);
 
 /**
  * Opens a uart, either by device name, or if that fails it will search

--- a/simple_uart.h
+++ b/simple_uart.h
@@ -6,6 +6,7 @@ extern "C" {
 #endif
 
 #include <stdbool.h>
+#include <stdint.h>
 
 #ifdef WIN32
 #include <windows.h>


### PR DESCRIPTION
Hello Andre,

I started with fixing compile warnings under Windows/MSYS2. At the moment are they pending.

```bash
./inc/simple_uart/simple_uart.c: In function 'simple_uart_set_config':
./inc/simple_uart/simple_uart.c:153:82: warning: unused parameter 'mode_string' [-Wunused-parameter]
  153 | static int simple_uart_set_config(struct simple_uart *sc, int speed, const char *mode_string)
      |                                                                      ~~~~~~~~~~~~^~~~~~~~~~~
./inc/simple_uart/simple_uart.c: In function 'simple_uart_list':
./inc/simple_uart/simple_uart.c:446:50: warning: unused parameter 'descriptionp' [-Wunused-parameter]
  446 | ssize_t simple_uart_list(char ***namesp, char ***descriptionp)
      |                                          ~~~~~~~~^~~~~~~~~~~~
./inc/simple_uart/simple_uart.c: In function 'simple_uart_read_line':
./inc/simple_uart/simple_uart.c:50:20: warning: conversion to 'int' from 'DWORD' {aka 'long unsigned int'} may change the sign of the result [-Wsign-conversion]
   50 | #define mseconds() GetTickCount()
      |                    ^~~~~~~~~~~~
./inc/simple_uart/simple_uart.c:541:16: note: in expansion of macro 'mseconds'
  541 |     int last = mseconds();
      |                ^~~~~~~~
./inc/simple_uart/simple_uart.c:50:20: warning: conversion to 'int' from 'DWORD' {aka 'long unsigned int'} may change the sign of the result [-Wsign-conversion]
   50 | #define mseconds() GetTickCount()
      |                    ^~~~~~~~~~~~
./inc/simple_uart/simple_uart.c:542:15: note: in expansion of macro 'mseconds'
  542 |     int now = mseconds();
      |               ^~~~~~~~
./inc/simple_uart/simple_uart.c:50:20: warning: conversion to 'int' from 'DWORD' {aka 'long unsigned int'} may change the sign of the result [-Wsign-conversion]
   50 | #define mseconds() GetTickCount()
      |                    ^~~~~~~~~~~~
./inc/simple_uart/simple_uart.c:558:24: note: in expansion of macro 'mseconds'
  558 |                 last = mseconds();
      |                        ^~~~~~~~
./inc/simple_uart/simple_uart.c:50:20: warning: conversion to 'int' from 'DWORD' {aka 'long unsigned int'} may change the sign of the result [-Wsign-conversion]
   50 | #define mseconds() GetTickCount()
      |                    ^~~~~~~~~~~~
./inc/simple_uart/simple_uart.c:564:15: note: in expansion of macro 'mseconds'
  564 |         now = mseconds();
      |               ^~~~~~~~
```

 I need a little help with the macro. Here i need something with an saturate und then return.

```c
#define mseconds() GetTickCount()
```

Do you have an Idea for it?



Thanks. BR, Andreas