### PR TITLE
feature request to allow serial port names by udev rules 

### DIFF
--- a/simple_uart.c
+++ b/simple_uart.c
@@ -463,7 +463,7 @@ ssize_t simple_uart_list(char ***namesp)
     size_t count = 0;
 
 #ifdef __linux__
-    char *path_globs[] = {"/sys/class/tty/ttyS[0-9]*", "/sys/class/tty/ttyUSB[0-9]*", "/sys/class/tty/ttyACM[0-9]*"};
+    char *path_globs[] = {"/sys/class/tty/ttyS[0-9]*", "/dev/ttyUSB*", "/dev/ttyACM*"};
 #endif
 
 #ifdef __APPLE__


### PR DESCRIPTION
The problem: 
USB serial converter (specially cp210x) usually enumerate differently after every boot. To work around this under Linux people often use udev rules to give a specific USB serial converter a unique name. Such USB serial converter are currently masked out due to the name restriction `{"/sys/class/tty/ttyS[0-9]*", "/sys/class/tty/ttyUSB[0-9]*", "/sys/class/tty/ttyACM[0-9]*"};`

Possible solution: 
Don't restrict the names by `[0-9]*` and list devices from `/dev`. 

Please let me know what you think about this or if you can think of a better approach. 