### PR TITLE
simple uart windows, loaded libs only in lower case

### DIFF
--- a/simple_uart.c
+++ b/simple_uart.c
@@ -28,7 +28,7 @@
 #define INITGUID        // required for GUID_DEVCLASS_PORTS, otherwise linker error @see https://stackoverflow.com/questions/14762154/enumerating-battery-devices-c-windows
 #include <windows.h>
 #include <devguid.h>    // GUID_DEVCLASS_PORTS
-#include <Setupapi.h>   // Devices: SetupDiGetClassDevs
+#include <setupapi.h>   // Devices: SetupDiGetClassDevs
 #endif
 
 #ifdef __linux__

--- a/simple_uart.h
+++ b/simple_uart.h
@@ -10,7 +10,7 @@ extern "C" {
 
 #ifdef _WIN32
 #include <windows.h>
-#include <BaseTsd.h>
+#include <basetsd.h>
 typedef SSIZE_T ssize_t;
 #endif
 


### PR DESCRIPTION
As described in #34 windows libs in lower case.
