### PR TITLE
Minor updates to library to support msvc and XON/XOFF

### DIFF
--- a/simple_uart.c
+++ b/simple_uart.c
@@ -1,5 +1,8 @@
 #ifdef _MSC_VER
 #define _CRT_SECURE_NO_WARNINGS
+#ifndef PATH_MAX
+#define PATH_MAX MAX_PATH
+#endif /* PATH_MAX */
 #endif /* _MSC_VER */
 
 #define _GNU_SOURCE

--- a/simple_uart.c
+++ b/simple_uart.c
@@ -256,6 +256,15 @@ static int simple_uart_set_config(struct simple_uart *sc, int speed, const char 
     } else {
         options.fRtsControl = RTS_CONTROL_DISABLE;
     }
+    // XON/XOFF
+    if (HAS_OPTION('X')) {
+        options.fOutX = TRUE;
+        options.fInX = TRUE;
+    } else {
+        options.fOutX = FALSE;
+        options.fInX = FALSE;
+    }
+
     /* mandatory options */
     options.fBinary = TRUE;
     /* assign to port */

--- a/simple_uart.c
+++ b/simple_uart.c
@@ -267,6 +267,7 @@ static int simple_uart_set_config(struct simple_uart *sc, int speed, const char 
 
     /* mandatory options */
     options.fBinary = TRUE;
+    options.fDtrControl = FALSE;
     /* assign to port */
     if (!SetCommState(sc->port, &options))
         return win32_errno();

--- a/simple_uart.c
+++ b/simple_uart.c
@@ -1,3 +1,7 @@
+#ifdef _MSC_VER
+#define _CRT_SECURE_NO_WARNINGS
+#endif /* _MSC_VER */
+
 #define _GNU_SOURCE
 #include <ctype.h>
 #include <errno.h>

--- a/simple_uart.c
+++ b/simple_uart.c
@@ -756,14 +756,14 @@ int simple_uart_describe(const char *uart, char *description, size_t max_desc_le
 int simple_uart_set_logfile(struct simple_uart *uart, const char *logfile, ...)
 {
     va_list ap;
-    char *buffer;
+    char buffer[PATH_MAX];
     int len;
 
     if (!uart || !logfile)
         return -EINVAL;
 
     va_start(ap, logfile);
-    len = vasprintf(&buffer, logfile, ap);
+    len = vsprintf(buffer, logfile, ap);
     va_end(ap);
     if (len < 0)
         return -errno;
@@ -774,10 +774,8 @@ int simple_uart_set_logfile(struct simple_uart *uart, const char *logfile, ...)
     uart->logfile = fopen(buffer, "a");
     if (!uart->logfile) {
         int e = -errno;
-        free(buffer);
         return e;
     }
-    free(buffer);
     return 0;
 }
 

--- a/simple_uart.c
+++ b/simple_uart.c
@@ -376,6 +376,11 @@ static int simple_uart_set_config(struct simple_uart *sc, int speed, const char 
     else
         options.c_cflag &= ~CRTSCTS;
 
+    /* clear and set software flow control */
+    options.c_iflag &= (tcflag_t) ~(IXON | IXOFF | IXANY);
+    if (HAS_OPTION('X'))
+        options.c_iflag |= IXON | IXOFF;
+
     // raw input mode
     options.c_lflag &= (tcflag_t) ~(ICANON | ECHO | ECHOE | ISIG);
 
@@ -766,7 +771,7 @@ int simple_uart_set_logfile(struct simple_uart *uart, const char *logfile, ...)
         return -EINVAL;
 
     va_start(ap, logfile);
-    len = vsprintf(buffer, logfile, ap);
+    len = vsnprintf(buffer, sizeof(buffer), logfile, ap);
     va_end(ap);
     if (len < 0)
         return -errno;


### PR DESCRIPTION
Hello Andre,

Here is a small update to the library:

1) Support MSVC without warnings
2) Support XON/XOFF, as needed for 2 wire communication on some devices
3) Disable DTR by default, as some USB adapters set this, making libary unusable
4) Add missing PATH_MAX on MSVC
5) Dont use vasprintf, not available on all platforms